### PR TITLE
Update cmake.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest] 
+        os: [ubuntu-latest, windows-2019, macOS-latest] 
     
     steps:
     - name: Install Linux Deps


### PR DESCRIPTION
Appears to be breaking changes in building JUCE from VS2019 to VS2022, observed in the github actions using "windows-latest". Specifying "windows-2019"